### PR TITLE
Fix API query execution

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -19,7 +19,15 @@ def query():
     if not question:
         return jsonify({"error": "No question provided"}), 400
     sql = generate_sql(question)
-    return jsonify({"sql": sql})
+    conn_str = os.getenv("DB_CONN_STR")
+    if not conn_str:
+        return jsonify({"error": "Database connection string not configured", "sql": sql}), 500
+    try:
+        df = run_query(conn_str, sql)
+        result = df.to_dict(orient="records")
+        return jsonify({"sql": sql, "result": result})
+    except Exception as e:
+        return jsonify({"error": str(e), "sql": sql}), 500
 
 @app.route("/")
 def serve_index():

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,11 @@ def main():
         nl_query = input("\nAsk your question (or type 'exit'): ")
         if nl_query.lower() == 'exit':
             break
-        sql = generate_sql(schema, nl_query)
+        # generate_sql only requires the natural language question. The previous
+        # implementation passed the database schema as the first argument which
+        # caused the question to be interpreted as the model name. This resulted
+        # in invalid API calls. We now pass only the question.
+        sql = generate_sql(nl_query)
         print("\nGenerated SQL:\n", sql)
         try:
             df = run_query(conn_str, sql)


### PR DESCRIPTION
## Summary
- fix mis-ordered arguments in the CLI app
- run SQL queries in `/api/query` so the UI receives results

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68599f73f56883298c84bc7c117e80cd